### PR TITLE
Python 3.5.1 needs urllib.request module for urlretrieve.

### DIFF
--- a/hipsternet/input_data.py
+++ b/hipsternet/input_data.py
@@ -1,7 +1,7 @@
 """Functions for downloading and reading MNIST data."""
 import gzip
 import os
-import urllib
+import urllib.request
 import numpy
 SOURCE_URL = 'http://yann.lecun.com/exdb/mnist/'
 
@@ -12,7 +12,7 @@ def maybe_download(filename, work_directory):
         os.mkdir(work_directory)
     filepath = os.path.join(work_directory, filename)
     if not os.path.exists(filepath):
-        filepath, _ = urllib.urlretrieve(SOURCE_URL + filename, filepath)
+        filepath, _ = urllib.request.urlretrieve(SOURCE_URL + filename, filepath)
         statinfo = os.stat(filepath)
         print('Succesfully downloaded', filename, statinfo.st_size, 'bytes.')
     return filepath


### PR DESCRIPTION
The python vesion is forced via conda in the environment.yaml. On a clean data folder 
> python run_cnn.py ff 
will fail to download mnist data.